### PR TITLE
silence werror

### DIFF
--- a/alignocator.h
+++ b/alignocator.h
@@ -76,7 +76,7 @@ public:
     // Returns true if and only if storage allocated from *this
     // can be deallocated from other, and vice versa.
     // Always returns true for stateless allocators.
-    bool operator==(const alignocator& other) const {
+    bool operator==(const alignocator& /*other*/) const {
         return true;
     }
  
@@ -131,7 +131,7 @@ public:
         return static_cast<T *>(pv);
     }
  
-    void deallocate(T * const p, const size_t n) const {
+    void deallocate(T * const p, const size_t /*n*/) const {
         // alignocator prints a diagnostic message to demonstrate
         // what it's doing. Real allocators won't do this.
        // std::cout << "Deallocating " << n << (n == 1 ? " object" : "objects")


### PR DESCRIPTION
I was testing out your allocator for some AVX things

for the case of float/8 (__m256) it has proved necessary, but not for float/4, double/2 or double/4